### PR TITLE
With st

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN make -j CMAKE_BUILD_TYPE=Release && make -j install
 # Base config. Contains neovim plugins for git, code navigation, and style.
 FROM git_layer AS neovim_config_base
 
-RUN apk add curl && \
+RUN apk add curl st font-hack-nerd && \
     git clone --depth 1 https://github.com/wbthomason/packer.nvim \
     ${XDG_DATA_HOME}/nvim/site/pack/packer/start/packer.nvim && \
     git clone --depth 1 --branch base-ide \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN make -j CMAKE_BUILD_TYPE=Release && make -j install
 # Base config. Contains neovim plugins for git, code navigation, and style.
 FROM git_layer AS neovim_config_base
 
-RUN apk add curl st font-hack-nerd && \
+RUN apk add curl st && \
     git clone --depth 1 https://github.com/wbthomason/packer.nvim \
     ${XDG_DATA_HOME}/nvim/site/pack/packer/start/packer.nvim && \
     git clone --depth 1 --branch base-ide \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,13 +28,11 @@ RUN make -j CMAKE_BUILD_TYPE=Release && make -j install
 # Base config. Contains neovim plugins for git, code navigation, and style.
 FROM git_layer AS neovim_config_base
 
-RUN apk add curl st && \
+RUN apk add curl && \
     git clone --depth 1 https://github.com/wbthomason/packer.nvim \
     ${XDG_DATA_HOME}/nvim/site/pack/packer/start/packer.nvim && \
     git clone --depth 1 --branch base-ide \
     https://github.com/davidbloss/neovim-ide.git ${XDG_CONFIG_HOME}/nvim && \
-    mkdir -p ${XDG_DATA_HOME}/fonts && cd ${XDG_DATA_HOME}/fonts && \
-    curl -fLo "Hack Regular Nerd Font Complete.ttf" https://github.com/ryanoasis/nerd-fonts/raw/master/patched-fonts/Hack/Regular/complete/Hack%20Regular%20Nerd%20Font%20Complete.ttf && \
     apk del curl
 
 # Final product - all build, config, etc. brought in from prior image
@@ -42,10 +40,11 @@ FROM neovim_config_base AS neovim_base
 
 WORKDIR /home
 
-RUN apk add g++ ripgrep
+RUN apk add font-hack-nerd g++ ripgrep st
 COPY --from=neovim_build /usr/local/bin/nvim /usr/local/bin/nvim
 COPY --from=neovim_build /usr/local/share/nvim/runtime /usr/local/share/nvim/runtime
 RUN nvim --headless -c 'autocmd User PackerComplete quitall' -c 'PackerSync'
 
-ENTRYPOINT ["nvim"]
+# Start neovim instide of st (simple terminal)
+ENTRYPOINT ["st", "-f", "font-hack-nerd", "--", "nvim"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,11 +40,10 @@ FROM neovim_config_base AS neovim_base
 
 WORKDIR /home
 
-RUN apk add font-hack-nerd g++ ripgrep st
+RUN apk add g++ ripgrep
 COPY --from=neovim_build /usr/local/bin/nvim /usr/local/bin/nvim
 COPY --from=neovim_build /usr/local/share/nvim/runtime /usr/local/share/nvim/runtime
 RUN nvim --headless -c 'autocmd User PackerComplete quitall' -c 'PackerSync'
 
-# Start neovim instide of st (simple terminal)
-ENTRYPOINT ["st", "-f", "font-hack-nerd", "--", "nvim"]
+ENTRYPOINT ["nvim"]
 

--- a/shells/Dockerfile
+++ b/shells/Dockerfile
@@ -1,1 +1,0 @@
-# TODO: standalone shell stuff that can be pulled into Neovim IDE

--- a/shells/Dockerfile.with_st
+++ b/shells/Dockerfile.with_st
@@ -1,0 +1,8 @@
+FROM neovim_base as neovim_with_st
+
+ARG ST_FONT=font-hack-nerd
+
+RUN apk add st ${ST_FONT}
+
+# Start neovim instide of st (simple terminal)
+ENTRYPOINT ["st", "-f", "${ST_FONT}", "--", "nvim"]


### PR DESCRIPTION
[st](https://st.suckless.org/ "Simple Terminal") added in separate Dockerfile built on top of *neovim_base* image.

`st` made an option to enable true color and custom fonts without having to learn how to configure these things directly.